### PR TITLE
fix error when using validator created from xsd string

### DIFF
--- a/src/clj_xml_validation/core.clj
+++ b/src/clj_xml_validation/core.clj
@@ -62,15 +62,14 @@
   "Create a function that when called will validate an XML stream source"
   [& schemas]
   {:pre [(every? (partial satisfies? StreamSourcable) schemas)]}
-  (let [sources (into-array StreamSource (map stream-source schemas))]
-    ;; ensure schemas are valid
-    (validator-from-schemas sources)
+  (let [sources (into-array StreamSource (map stream-source schemas))
+        validator (validator-from-schemas sources) ;; do this here to ensure schemas are valid
+        ]
 
     (fn [xmldoc]
       {:pre [(satisfies? StreamSourcable xmldoc)]}
       (try
-        (let [validator (validator-from-schemas sources)
-              errs (atom [])
+        (let [errs (atom [])
               _ (.setErrorHandler validator (create-error-handler errs))]
 
           (.validate validator (stream-source xmldoc))

--- a/src/clj_xml_validation/core.clj
+++ b/src/clj_xml_validation/core.clj
@@ -1,5 +1,6 @@
 (ns clj-xml-validation.core
-  (:require [clojure.java.io :as io])
+  (:require [clojure.java.io :as io]
+            [clojure.set :as set])
   (:import [javax.xml XMLConstants]
            [org.xml.sax SAXException ErrorHandler SAXParseException]
            [javax.xml.validation SchemaFactory]
@@ -39,8 +40,8 @@
   [source exc]
   (->
     (bean exc)
-    (clojure.set/rename-keys {:lineNumber :line-number
-                              :columnNumber :column-number})
+    (set/rename-keys {:lineNumber :line-number
+                      :columnNumber :column-number})
     (select-keys [:message :line-number :column-number])
     (assoc :source source)))
 

--- a/test/clj_xml_validation/core_test.clj
+++ b/test/clj_xml_validation/core_test.clj
@@ -5,6 +5,12 @@
 (def validate (create-validation-fn (clojure.java.io/resource "example.xsd")))
 (def validate-two (create-validation-fn (clojure.java.io/resource "example2.xsd") (clojure.java.io/resource "example3.xsd")))
 
+(def xsd-str
+  "<?xml version=\"1.0\"?>
+    <xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">
+    <xs:element name=\"foo\" type=\"xs:string\" />
+    </xs:schema>\n")
+
 (deftest obviously-wrong
   (testing "Validator throws exception on unparseable XML"
     (is (thrown? clojure.lang.ExceptionInfo (validate "<wrong>")))))
@@ -40,3 +46,8 @@
   (testing "validator with 2 schemas fails if either type of xml is malformed"
     (is (thrown? clojure.lang.ExceptionInfo (validate-two "<wrong<")))))
 
+(deftest xsd-from-string
+  (testing "Validation works when xsd is read from string"
+    (let [validate (create-validation-fn xsd-str)]
+      (is (valid? (validate "<foo>asdf</foo>")))
+      (is (not (valid? (validate "<bar />")))))))


### PR DESCRIPTION
Without the changes to core, the new test fails. I haven't gone all the way down to the core of it but it seems that calling `(validator-from-schemas sources)` twice works for some types of InputStreams but not for others.